### PR TITLE
Add coredump directory to sandbox

### DIFF
--- a/coredump/CMakeLists.txt
+++ b/coredump/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.29)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+if(NOT WIN32)
+  # Add debug info for all builds
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
+else()
+  # Add debug info for all builds
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zi")
+  # Disable optimization in Debug builds for better debugging
+  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /Od")
+  
+  # Instruct the linker to generate .pdb files for all builds
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /DEBUG")
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /DEBUG")
+  
+  # Optimization flags in Release builds
+  set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /OPT:REF /OPT:ICF")
+  set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} /OPT:REF /OPT:ICF")
+endif()
+
+project(CoredumpSandbox)
+
+add_executable(CoredumpMain main.cpp)

--- a/coredump/CMakePresets.json
+++ b/coredump/CMakePresets.json
@@ -1,0 +1,33 @@
+{
+  "version": 2,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 29,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "base",
+      "description": "Inherited by all other presets",
+      "binaryDir": "${sourceDir}/../build",
+      "hidden": true
+    },
+    {
+      "name": "ninja",
+      "description": "Build options for a Ninja generator",
+      "inherits": [
+        "base"
+      ],
+      "generator": "Ninja"
+    },
+    {
+      "name": "win-vs",
+      "description": "Build options for a Windows build using Visual Studio 2022",
+      "inherits": [
+        "base"
+      ],
+      "generator": "Visual Studio 17 2022",
+      "toolset": "v142"
+    }
+  ]
+}

--- a/coredump/environment.yml
+++ b/coredump/environment.yml
@@ -1,0 +1,9 @@
+name: dev-env
+
+channels:
+  - conda-forge
+
+dependencies:
+  - cmake
+  - compilers
+  - ninja

--- a/coredump/linux/README.md
+++ b/coredump/linux/README.md
@@ -1,0 +1,47 @@
+Build
+#####
+
+1. Configure and generate the project with:
+
+```sh
+cmake . -B build --preset ninja
+```
+
+2. Build the project with:
+
+```sh
+cd build && cmake --build .
+```
+
+Linux Setup
+###########
+
+1. Check and then set the core dump size:
+
+```sh
+ulimit -c
+ulimit -c unlimited
+```
+
+2. Customize where and how core dumps are saved:
+
+```sh
+sudo sysctl -w kernel.core_pattern=core.%e.%p
+```
+
+3. Run the project with:
+
+```sh
+cd build && ./CoredumpMain
+```
+
+4. Check for a `core.CoredumpMain.<pid>` file in the current working directory
+
+5. Use `gdb` to inspect the crash:
+
+```sh
+gdb ./CoredumpMain core.CoredumpMain.<pid>
+bt  # backtrace
+info locals  # Show local variables
+```
+

--- a/coredump/main.cpp
+++ b/coredump/main.cpp
@@ -1,0 +1,11 @@
+#include <iostream>
+
+
+int main(int argc, char *argv[]) {
+  std::cout << "In main..." << std::endl;
+
+  int* ptr = nullptr;
+  std::cout << *ptr << std::endl;  // Dereferencing nullptr causes crash
+
+  return 0;
+}

--- a/coredump/windows/EnableCrashDumps.reg
+++ b/coredump/windows/EnableCrashDumps.reg
@@ -1,0 +1,6 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps]
+"DumpFolder"="C:\\CrashDumps"
+"DumpCount"=dword:00000010
+"DumpType"=dword:00000002   ; 2 = full dump, 1 = mini

--- a/coredump/windows/README.md
+++ b/coredump/windows/README.md
@@ -1,0 +1,44 @@
+Build
+#####
+
+1. Configure and generate the project with:
+
+```sh
+cmake . -B build --preset win-vs
+```
+
+2. Build the project with:
+
+```sh
+cd build && cmake --build .
+```
+
+Windows Setup
+#############
+
+The key to this is to ensure when you build the executable, there are `.pdb` files which are generated alongside it.
+
+1. Create a `.reg` file with the following contents:
+
+```
+Windows Registry Editor Version 5.00
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps]
+"DumpFolder"="C:\\CrashDumps"
+"DumpCount"=dword:00000010
+"DumpType"=dword:00000002   ; 2 = full dump, 1 = mini
+```
+
+2. Double click this file in the File Explorer to apply it
+
+3. Run the project with:
+
+```sh
+cd build && ./CoredumpMain
+```
+
+4. Check for a `CoredumpMain.exe.<pid>.dmp` file in the current working directory, or `C:\CrashDumps`
+
+5. Copy this `.dmp` file to the same directory as the `.pdb` files
+
+6. From Visual Studio, open the `.dmp` file. Then select `Debug with Native Only` to see the call stack


### PR DESCRIPTION
Add coredump directory to sandbox for info generating a core dump for a crash in an environment where you do not have a debugger available.

The core dump can be copied to a machine with a debugger and run up to view the call stack before the crash.